### PR TITLE
chore: Rename opentelemetry extra to opentelemetry-sqlite3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -997,9 +997,9 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-opentelemetry = ["opentelemetry-instrumentation-sqlite3"]
+opentelemetry-sqlite3 = ["opentelemetry-instrumentation-sqlite3"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11 <3.13"
-content-hash = "4fa7685988bee25631140da079a3d55d9e28048c75145fd1b32c0d03c91f0ae1"
+content-hash = "4c596f21e16a3a3388022d5e30c73def39ba6aac2c1c006a60fcef61cf697f83"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ from = "src", include = "rate_limiter" }]
 repository = "https://github.com/preparingforexams/rate_limiter"
 
 [tool.poetry.extras]
-opentelemetry = [
+opentelemetry-sqlite3 = [
     "opentelemetry-instrumentation-sqlite3",
 ]
 


### PR DESCRIPTION
BREAKING CHANGE: The `opentelemetry` extra has been renamed to `opentelemetry-sqlite3`